### PR TITLE
add: redux slice with caching for modals

### DIFF
--- a/src/components/FiltersSection.jsx
+++ b/src/components/FiltersSection.jsx
@@ -1,37 +1,25 @@
 import { ArrowUpDown, SlidersHorizontal } from "lucide-react";
 import React from "react";
 import FilterButton from "./granular/FilterButton";
-const data = [
-    { id: 1, name: "India", isDefault: true },
-    { id: 2, name: "Canada" },
-    { id: 3, name: "France" },
-    { id: 4, name: "China" },
-    { id: 5, name: "Iran" },
-  ];
-const sorts = [
-    {
-        id: 1, name: "A-Z"
-    },
-    {
-        id: 2, name: "Z-A"
-    }
-]
+import { useDispatch, useSelector } from "react-redux";
+import { fetchFoodByArea, setSortOption } from "../store/slices/FoodMenuSlice";
+
+const sorts = ['A-Z', 'Z-A'];
 const FiltersSection = () => {
-    const handleFilterApply = (selectedItem) => {
-        console.log('Filter applied with:', selectedItem);
-      };
+    const {areas} = useSelector(state => state.foodMenu);
+    const dispatch = useDispatch();
 	return (
 		<div className="w-full flex flex-col gap-2 rounded-md ring ring-orange-100 ring-offset-1 p-2 bg-white">
-			<h1>Restaurants with online food delivery in Pune</h1>
+			<h1>Spice It Right – Filter Your Cravings, Sort Your Feast! 🍛🍕🍔</h1>
 			<nav>
 				<ul className="flex gap-2 items-center list-none">
 					<li>
-						<FilterButton items={data}>
+						<FilterButton items={areas} onApply={(area) => dispatch(fetchFoodByArea(area))} >
                             Filter <SlidersHorizontal size={16} className="text-xs" />
                         </FilterButton>
 					</li>
 					<li>
-						<FilterButton items={sorts}>
+						<FilterButton items={sorts} onApply={(sortOption) => dispatch(setSortOption(sortOption))} >
                             Sort <ArrowUpDown size={16} className="text-xs" />
                         </FilterButton>
 					</li>
@@ -40,6 +28,5 @@ const FiltersSection = () => {
 		</div>
 	);
 };
-//
-// 
+
 export default FiltersSection;

--- a/src/components/FoodItemCard.jsx
+++ b/src/components/FoodItemCard.jsx
@@ -9,7 +9,7 @@ const FoodItemCard = ({ id, setActiveDishId, img, name, rating }) => {
 				src={img}
 				alt={name}
 			/>
-			<div className="flex gap-2">
+			<div>
 				<h1 className="text-lg font-bold text-pretty">{name}</h1>
 				<Rating rate={rating} />
 			</div>

--- a/src/components/FoodMenu.jsx
+++ b/src/components/FoodMenu.jsx
@@ -1,22 +1,28 @@
 import React, { useState } from "react";
 import FoodItemCard from "./FoodItemCard";
 import FoodItemModal from "./FoodItemModal";
+import { useSelector } from "react-redux";
 
 const FoodMenu = () => {
 	const [activeDishId, setActiveDishId] = useState(null);
+	const { menu } = useSelector((state) => state.foodMenu);
+
 	return (
 		<>
 			<div className="w-full grid grid-cols-4 gap-4 p-4">
-				<FoodItemCard
-					id={52772}
-                    setActiveDishId={setActiveDishId}
-                    openModal={() => setIsModalOpen(true)}
-					img={
-						"https://www.themealdb.com/images/media/meals/ypxvwv1505333929.jpg"
-					}
-					name="Al Fungi Pizza"
-					rating={4}
-				/>
+                {menu.map((item)=> {
+                    return (
+                        <FoodItemCard
+                            key={item.idMeal}
+                            id={item.idMeal}
+                            setActiveDishId={setActiveDishId}
+                            openModal={() => setIsModalOpen(true)}
+                            img={item.strMealThumb}
+                            name={item.strMeal}
+                            rating={Math.floor(Math.random() * 5) + 1} // random rating between 1 and 5
+                        />
+                    )
+                })}
 			</div>
 			<FoodItemModal
 				isOpen={activeDishId !== null}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,7 +3,7 @@ import SearchBar from './granular/SearchBar'
 
 const Header = () => {
   return (
-    <header className='px-12 h-20 w-full bg-white'>
+    <header className='px-12 h-20 w-full bg-white sticky top-0 z-20'>
       <div className='h-full w-full flex items-center justify-between'>
         <img className='w-32 object-contain' src="/swiggy-logo.png" alt="swiggy-logo" />
         <SearchBar />

--- a/src/components/granular/FilterButton.jsx
+++ b/src/components/granular/FilterButton.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import FilterDropdown from "./FilterDropdown";
 
-const FilterButton = ({ children, items = [] }) => {
+const FilterButton = ({ children, items = [], onApply }) => {
 	const [expand, setExpand] = useState(false);
 
 	return (
@@ -18,7 +18,7 @@ const FilterButton = ({ children, items = [] }) => {
                     onBlur={() => setExpand(false)}
 					onApply={(selectedItem) => {
 						setExpand(false);
-						alert(JSON.stringify(selectedItem));
+						onApply(selectedItem);
 					}}
 				/>
 			)}

--- a/src/components/granular/FilterDropdown.jsx
+++ b/src/components/granular/FilterDropdown.jsx
@@ -7,9 +7,7 @@ import React, { useEffect, useRef, useState } from "react";
  * @param {Object} position - Object containing top, left, and width for dropdown positioning.
  */
 const FilterDropdown = ({ items = [], onApply, onBlur }) => {
-	const [selectedItem, setSelectedItem] = useState(
-		items.find((item) => item.isDefault)?.id
-	);
+	const [selectedItem, setSelectedItem] = useState("");
     const ref = useRef(null);
     useEffect(() => {
 		const handleClickOutside = (event) => {
@@ -24,24 +22,24 @@ const FilterDropdown = ({ items = [], onApply, onBlur }) => {
 	return (
 		<div ref={ref} className="absolute bg-white rounded-xl shadow-lg p-4 w-48 z-50 transition-all duration-300">
 			<ul className="flex flex-col gap-2 list-none max-h-20 overflow-y-auto scrollbar">
-				{items.map((item) => (
+				{items.map((item, idx) => (
 					<li
 						className="w-full flex items-center justify-between px-2"
-						key={item.id}
+						key={idx}
 					>
 						<label
-							htmlFor={`radio-${item.id}`}
+							htmlFor={`radio-${item}`}
 							className="text-sm font-medium text-gray-900 cursor-pointer"
 						>
-							{item.name}
+							{item}
 						</label>
 						<input
-							checked={selectedItem === item.id}
-							id={`radio-${item.id}`}
+							checked={selectedItem === item}
+							id={`radio-${item}`}
 							type="radio"
-							value={item.id}
+							value={item}
 							name="filter-radio"
-							onChange={() => setSelectedItem(item.id)}
+							onChange={() => setSelectedItem(item)}
 							className="w-4 h-4 text-orange-500 bg-gray-100 border-gray-300 focus:ring-orange-600 focus:ring-2"
 						/>
 					</li>
@@ -50,7 +48,7 @@ const FilterDropdown = ({ items = [], onApply, onBlur }) => {
 			<button
 				className="p-2 mt-2 bg-orange-500 text-white w-full rounded-md hover:bg-orange-600"
 				onClick={() =>
-					onApply(items.find((item) => item.id === selectedItem))
+					onApply(selectedItem)
 				}
 			>
 				Apply

--- a/src/hooks/useDishModal.js
+++ b/src/hooks/useDishModal.js
@@ -1,40 +1,45 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
+import { fetchInfo } from "../utils";
+
 /*
  * @param disId is the id by which this hook will fetch info about the dish
  * @returns { dish, isLoading }
  */
+// prevent calling the api again if the same dish is already fetched and in the cache
+const dishCache = new Map();
+function addToCache(dishId, data) {
+	if (dishCache.size >= 3) {
+		const oldestKey = dishCache.keys().next().value;
+		dishCache.delete(oldestKey);
+	}
+	dishCache.set(dishId, data);
+}
 export function useDishModal(dishId) {
 	const [dish, setDish] = useState(null);
 	const [isLoading, setIsLoading] = useState(false);
 
 	useEffect(() => {
 		if (!dishId) return; // No fetch call if dishId is falsy
-		async function fetchInfo() {
-			try {
-				setIsLoading(true);
-				await new Promise((res) => setTimeout(res, 10000));
-				const res = await axios.get(
-					`https://www.themealdb.com/api/json/v1/1/lookup.php?i=${dishId}`
-				);
-				const meal = res.data.meals[0];
-				const data = {
-					idMeal: meal.idMeal,
-					name: meal.strMeal,
-					category: meal.strCategory,
-					area: meal.strArea,
-					instructions: meal.strInstructions,
-					thumbnail: meal.strMealThumb,
-					youtube: meal.strYoutube.split("v=")[1],
-				};
-				setDish(data);
-			} catch (error) {
-				console.error("error while fetching dish info: ", error);
-			} finally {
-				setIsLoading(false);
-			}
+
+		// Check if dish is already cached
+		if (dishCache.has(dishId)) {
+			setDish(dishCache.get(dishId));
+			return; // Skip API call if cached
 		}
-		fetchInfo();
+
+		// Fetch dish info and add to cache
+		async function getInfo() {
+			setIsLoading(true);
+			const data = await fetchInfo(dishId);
+			if (data) {
+				setDish(data);
+				addToCache(dishId, data); // Add to cache
+			}
+			setIsLoading(false);
+		}
+
+		getInfo();
 	}, [dishId]);
 
 	return { isLoading, dish };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,11 +1,19 @@
-import {useState} from "react";
+import { useEffect, useState } from "react";
 import FiltersSection from "../components/FiltersSection";
 import FoodMenu from "../components/FoodMenu";
 import FoodItemModal from "../components/FoodItemModal";
+import { useDispatch } from "react-redux";
+import { fetchAreas, fetchFoodByArea } from "../store/slices/FoodMenuSlice";
 
 const HomePage = () => {
+	const dispatch = useDispatch();
+    // initialize state
+	useEffect(() => {
+		dispatch(fetchAreas());
+		dispatch(fetchFoodByArea("Indian"));
+	}, [dispatch]);
 	return (
-		<main className="py-10 px-20 max-md:px-8">
+		<main className="relative py-10 px-20 max-md:px-8">
 			<FiltersSection />
 			<div className="w-full mt-6">
 				<FoodMenu />

--- a/src/store/slices/FoodMenuSlice.js
+++ b/src/store/slices/FoodMenuSlice.js
@@ -1,19 +1,72 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+
+const API_BASE_URL = 'https://www.themealdb.com/api/json/v1/1/';
+
+// Thunk to fetch available areas
+export const fetchAreas = createAsyncThunk('foodMenu/fetchAreas', async () => {
+  const response = await axios.get(`${API_BASE_URL}list.php?a=list`);
+  return response.data.meals.map(area => area.strArea);
+});
+
+// Thunk to fetch food items filtered by area
+export const fetchFoodByArea = createAsyncThunk('foodMenu/fetchFoodByArea', async (area) => {
+  const response = await axios.get(`${API_BASE_URL}filter.php?a=${area}`);
+  return response.data.meals;
+});
 
 const initialState = {
-    menu: [],
-    pagination: {
-        currentPage: 0,
-        totalPages: 0
-    },
-    isLoading: false
-}
+  menu: [], // Food items
+  areas: [], // Available areas from API
+  selectedArea: 'Indian', // Default area
+  sortOption: 'A-Z', // Default sorting option
+  isLoading: false,
+  error: null
+};
 
 const foodMenuSlice = createSlice({
-    name: "foodMenu",
-    initialState,
-    reducers: {},
-    builder: (builder) => {
-        builder.addCase
-    }
-})
+  name: "foodMenu",
+  initialState,
+  reducers: {
+    // Change sorting order (A-Z or Z-A)
+    setSortOption(state, action) {
+      state.sortOption = action.payload;
+      state.menu = [...state.menu].sort((a, b) => {
+        if (action.payload === 'A-Z') return a.strMeal.localeCompare(b.strMeal);
+        if (action.payload === 'Z-A') return b.strMeal.localeCompare(a.strMeal);
+        return 0;
+      });
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // Handle fetching of areas
+      .addCase(fetchAreas.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(fetchAreas.fulfilled, (state, action) => {
+        state.areas = action.payload;
+        state.isLoading = false;
+      })
+      .addCase(fetchAreas.rejected, (state, action) => {
+        state.error = action.error.message;
+        state.isLoading = false;
+      })
+      // Handle fetching of food items by area
+      .addCase(fetchFoodByArea.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(fetchFoodByArea.fulfilled, (state, action) => {
+        state.menu = action.payload;
+        state.isLoading = false;
+      })
+      .addCase(fetchFoodByArea.rejected, (state, action) => {
+        state.error = action.error.message;
+        state.isLoading = false;
+      });
+  }
+});
+
+export const { setSortOption } = foodMenuSlice.actions;
+
+export default foodMenuSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
-
+import foodMenuSliceReducer from "./slices/FoodMenuSlice";
 export const store = configureStore({
     reducer: {
+        foodMenu: foodMenuSliceReducer
     }
 })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+export async function fetchInfo(dishId) {
+    try {
+        //await new Promise((res) => setTimeout(res, 10000)); // for testing
+        const res = await axios.get(
+            `https://www.themealdb.com/api/json/v1/1/lookup.php?i=${dishId}`
+        );
+        const meal = res.data.meals[0];
+        const data = {
+            idMeal: meal.idMeal,
+            name: meal.strMeal,
+            category: meal.strCategory,
+            area: meal.strArea,
+            instructions: meal.strInstructions,
+            thumbnail: meal.strMealThumb,
+            youtube: meal.strYoutube.split("v=")[1],
+        };
+        return data;
+    } catch (error) {
+        console.error("error while fetching dish info: ", error);
+        return null;
+    }
+}


### PR DESCRIPTION
1. A single redux slice for the menu page with handling filtering and sorting.
2. The slice has two async thunks- one for area based menu items fetching and other for getting all possible areas.
3. I have added a small cache for the modal custom hook which uses the HashMap of JS to prevent api calls if same dish is being opened again. This improves speed and reduces api calls.
4. Sorting for both A-Z and Z-A order as mentioned in task description.
5. Area based filtering for entire menu. (The api does not have pagination so will set it up in UI).
6. Improved the card UI by moving rating below the title of the card.